### PR TITLE
Fix hybrid module opening flow scaling

### DIFF
--- a/src/nodalAnalysis/NodalAnalysis.hh
+++ b/src/nodalAnalysis/NodalAnalysis.hh
@@ -393,10 +393,10 @@ void NodalAnalysis<T>::writeCfdSimulators(const std::unordered_map<int, std::sha
             // Communicate the flow rate to the module
             else if (contains(groundNodeIds, key)) {
                 T old_flowRate = old_flowrates.at(key) ;
-                T new_flowRate = x(groundNodeIds.at(key)) / cfdSimulator.second->getModule()->getOpenings().at(key).width;
+                T new_flowRate = x(groundNodeIds.at(key)) / cfdSimulator.second->getModule()->getOpenings().at(key).height;
                 T set_flowRate = 0.0;
                 if (old_flowRate > 0 ) {
-                    set_flowRate = old_flowRate + 5 * cfdSimulator.second->getAlpha(key) *  ( new_flowRate - old_flowRate );
+                    set_flowRate = old_flowRate + cfdSimulator.second->getBeta(key) *  ( new_flowRate - old_flowRate );
                 } else {
                     set_flowRate = new_flowRate;
                 }

--- a/src/porting/jsonReaders.hh
+++ b/src/porting/jsonReaders.hh
@@ -63,7 +63,7 @@ void readModules(json jsonString, arch::Network<T>& network) {
         for (auto& opening : module["Openings"]) {
             size_t nodeId = opening["node"];
             std::vector<T> normal = { opening["normal"]["x"], opening["normal"]["y"] };
-            arch::Opening<T> opening_(network.getNode(nodeId), normal, opening["width"]);
+            arch::Opening<T> opening_(network.getNode(nodeId), normal, opening["width"], opening["height"]);
             Openings.try_emplace(nodeId, opening_);
         }
         network.addCfdModule(position, size, stlFile, std::move(Openings));


### PR DESCRIPTION
## This PR updates

When running coupled CFD simulations I noticed they violated conservation of mass. When scaling width/height I noticed a discrepancy traceable to the fact that the benchmarks use height=width. I updated the scale factor for the flow rate from width to height and the issue vanished and my coupled CFD models now match. This problem may be related to a similar bug: https://github.com/cda-tum/mmft-simulator/issues/48
